### PR TITLE
Ensure node_modules are not overwritten with local copies in Dockerfile-run

### DIFF
--- a/Dockerfile-run
+++ b/Dockerfile-run
@@ -25,8 +25,8 @@ RUN apt-get update \
  && echo 'Finished installing dependencies'
 
 # Install app dependencies
-COPY --from=0 /app/node_modules /app/node_modules
 COPY . /app
+COPY --from=0 /app/node_modules /app/node_modules
 
 ENV NODE_ENV production
 ENV PORT 3000


### PR DESCRIPTION
Currently the Dockerfile-run:

1. Copies the installed node_modules from the build image into the run image
2. Copies the application files from the local directory into the image 

However if the local directory contains a node_modules directory, this overwrites the ones from the build image - which means we can have a architecture mis-match.

This PR switches the order so the application is copied in before coping the node_modules directory from the build image.