### PR TITLE
copying package-lock.json if there is one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ RUN apt-get update \
  && apt-get clean \
  && echo 'Finished installing dependencies'
 
+# Copy package.json and package-lock.json
+COPY package*.json .
+
 # Install npm production packages 
-COPY package.json /app/
-RUN cd /app; npm install --production
+RUN npm install --production
 
 COPY . /app
 

--- a/Dockerfile-run
+++ b/Dockerfile-run
@@ -9,8 +9,10 @@ RUN apt-get update \
  && apt-get clean \
  && echo 'Finished installing dependencies'
 
+# Copy package.json and package-lock.json
+COPY package*.json .
+
 # Install app dependencies
-COPY package.json /app/
 RUN npm install --production
 
 # Copy the dependencies into a Slim Node docker image


### PR DESCRIPTION
- we should copy package-lock.json if there is one in my app to ensue I get the same versions that i am developing/testing with

- removed the redundant cd app; command