### PR TITLE
Allow debug connections from all hosts by default

### DIFF
--- a/run-debug
+++ b/run-debug
@@ -7,7 +7,7 @@ CURRENT_NPM_VERSION=$(node -e "console.log(parseFloat(\"$CURRENT_NPM_VERSION\".r
 SUPPORT_NPM_INSPECT=$(echo "$CURRENT_NPM_VERSION > 6.2" | bc -l)
 
 if [ "$SUPPORT_NPM_INSPECT" == "1" ]; then
-	node --inspect server/server.js	
+	node --inspect=0.0.0.0 server/server.js	
 else
-	node --debug server/server.js	
+	node --debug=0.0.0.0 server/server.js	
 fi


### PR DESCRIPTION
Be default the debugger only allows connections from localhost. As we're enabling the use of a debugger inside a Docker container for connections from its host, those connections aren't from what the container thinks is localhost.

This PR changes the default in the run-debug script to accept connections from any host so that the use of debugging will work "out of the box"