### PR TITLE
Make install of nodemon global

### DIFF
--- a/Dockerfile-tools
+++ b/Dockerfile-tools
@@ -16,7 +16,7 @@ COPY run-debug /bin
 RUN chmod 777 /bin/run-dev /bin/run-debug
 
 # Install nodemon for use with "dev" mode
-RUN npm install nodemon
+RUN npm install -g nodemon
 
 # Bundle app source and install dependencies
 COPY . /app


### PR DESCRIPTION
This installs nodemon global so that it works for projects that don't have nodemon in their dependencies.