### PR TITLE
Update run-debug script

### DIFF
--- a/run-debug
+++ b/run-debug
@@ -1,13 +1,4 @@
 #!/bin/bash
 
-# Simple shell script to run debug mode. If using 6.2 or below use `--debug` otherwise use `--inspect`
-
-CURRENT_NPM_VERSION=$(node -v)
-CURRENT_NPM_VERSION=$(node -e "console.log(parseFloat(\"$CURRENT_NPM_VERSION\".replace(\"v\", \" \")).toFixed(1))")
-SUPPORT_NPM_INSPECT=$(echo "$CURRENT_NPM_VERSION > 6.2" | bc -l)
-
-if [ "$SUPPORT_NPM_INSPECT" == "1" ]; then
-	node --inspect=0.0.0.0 server/server.js	
-else
-	node --debug=0.0.0.0 server/server.js	
-fi
+# Simple shell script to run debug mode.
+node --inspect=0.0.0.0 server/server.js


### PR DESCRIPTION
The Dockerfiles in this repository run on Node.js 14 so the Node.js version checks for whether to use `--inspect`
are unnecessary (and were wrong anyway).